### PR TITLE
Fix linebreak and matcher bugs

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -40,7 +40,7 @@ var app = &cli.App{
 
 		}
 
-		fmt.Println(output)
+		fmt.Print(output)
 		return nil
 	},
 }

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -49,6 +49,16 @@ func TraverseNode(exp pp.Node, matchers *map[string]string) {
 
 func InjectLabelMatcher(e *pp.VectorSelector, matchers *map[string]string) {
 	for key, val := range *matchers {
+		var found = false
+		for _, existing := range e.LabelMatchers {
+			if existing.Name == key {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
 		e.LabelMatchers = append(
 			e.LabelMatchers,
 			&labels.Matcher{

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -40,6 +40,16 @@ func TestShouldApplyLabelMatcherToVectorSelector(t *testing.T) {
 			Matchers: map[string]string{"firstname": "Franz"},
 			Expected: `sum by(consumergroup) (kafka_consumergroup_lag{firstname="Franz"}) > 50`,
 		},
+		{
+			Input:    `up{cool="breeze",hot="sunrays"} == 0`,
+			Matchers: map[string]string{"cool": "stuff"},
+			Expected: `up{cool="breeze",hot="sunrays"} == 0`,
+		},
+		{
+			Input:    `up{cool="breeze",hot="sunrays"} == 0`,
+			Matchers: map[string]string{"cool": "stuff", "dance": "macarena"},
+			Expected: `up{cool="breeze",dance="macarena",hot="sunrays"} == 0`,
+		},
 	}
 	for _, c := range cases {
 		out, err := transform.Transform(c.Input, &c.Matchers)


### PR DESCRIPTION
resolves #1 
resolves #2 

## Issue
promql-transform currently is able to create expressions that are unable to match anything. it also outputs an unnecessary trailing line break that makes the output YAML look uglier than needed.

## Solution
Check for existing label matchers and skip if there is a collision.


## Context
N/A

## Testing Instructions
- Run promql-transform with a label matcher already present in the expression and make sure it's not added.
- Mix present and new label matchers and make sure the new ones are added
- Verify there is no line break at the end of the output.

## Release Notes
- Fixes an issue where adding label matchers already present would result in two matchers for the same name, making the expression not match anything.
- Fixes an issue where mutated expressions would get an unnecessary trailing line break.