### PR TITLE
Use a matrix to check and push to multiple charms

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,9 +45,12 @@ jobs:
   build:
     name: Release
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - test
       - lint
+    strategy:
+      matrix:
+        charm: [prometheus-k8s, grafana-k8s]
     env:
       CGO_ENABLED: 0
       TAG: ${{ github.event.release.tag_name }}
@@ -71,7 +74,7 @@ jobs:
         # Get the latest amd64 revision in CharmHub and increments it by one.
         # This assumes that the amd64 and arm64 revisions are in lockstep.
         run: |
-          echo "::set-output name=rev::$(($(charmcraft resource-revisions prometheus-k8s promql-transform-amd64 | tail -n+2 | head -1 | awk '{ print $1 }') + 1))"
+          echo "::set-output name=rev::$(($(charmcraft resource-revisions ${{ matrix.charm }} promql-transform-amd64 | tail -n+2 | head -1 | awk '{ print $1 }') + 1))"
       - name: Create artifacts
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -116,9 +119,9 @@ jobs:
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
         run: |
-          charmcraft upload-resource prometheus-k8s promql-transform-amd64 --file artifacts/promql-transform-amd64
+          charmcraft upload-resource ${{ matrix.charm }} promql-transform-amd64 --file artifacts/promql-transform-amd64
       - name: Upload arm64 resource revision to CharmHub
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
         run: |
-          charmcraft upload-resource prometheus-k8s promql-transform-arm64 --file artifacts/promql-transform-arm64
+          charmcraft upload-resource ${{ matrix.charm }} promql-transform-arm64 --file artifacts/promql-transform-arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Lint files
         run: |
           golangci-lint run
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -42,18 +43,13 @@ jobs:
       - name: Run tests
         run: |
           go test ./... -coverprofile coverage.out
+
   build:
-    name: Release
+    name: Build
     runs-on: ubuntu-latest
     needs:
-      - test
       - lint
-    strategy:
-      matrix:
-        charm: [prometheus-k8s, grafana-k8s]
-    env:
-      CGO_ENABLED: 0
-      TAG: ${{ github.event.release.tag_name }}
+      - test
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -64,17 +60,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-      - name: Install charmcraft
-        run: |
-          sudo snap install charmcraft --classic
-      - name: Retrieve current revision number
-        id: getrev
-        env:
-          CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
-        # Get the latest amd64 revision in CharmHub and increments it by one.
-        # This assumes that the amd64 and arm64 revisions are in lockstep.
-        run: |
-          echo "::set-output name=rev::$(($(charmcraft resource-revisions ${{ matrix.charm }} promql-transform-amd64 | tail -n+2 | head -1 | awk '{ print $1 }') + 1))"
       - name: Create artifacts
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -91,37 +76,95 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: promql-transform-amd64
-          path: dist/promql-transform_linux_amd64/promql-transform
+          # The v1 refers to the amd64 arch, see https://goreleaser.com/customization/build/
+          path: dist/promql-transform_linux_amd64_v1/promql-transform
       - name: Upload arm64 assets
         uses: actions/upload-artifact@v3
         with:
           name: promql-transform-arm64
           path: dist/promql-transform_linux_arm64/promql-transform
-      - name: Create tag
+
+  ghrelease:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d')"    
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Change perms on GITHUB_WORKSPACE
+        # Workaround for Git 2.34, see https://github.com/rickstaa/action-create-tag/issues/10
+        run: |
+          sudo chown -R root:root $GITHUB_WORKSPACE
+          sudo chmod -R 0777 $GITHUB_WORKSPACE
+      - name: Create release tag
         uses: rickstaa/action-create-tag@v1
         with:
-          tag: "rev${{ steps.getrev.outputs.rev }}"
-          message: "Revision ${{ steps.getrev.outputs.rev }}"
-      - name: Prepare artifacts for attachment to release
+          tag: "rel-${{ steps.date.outputs.date }}"
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts/
+      - name: Prepare artifacts for release
         run: |
-          mkdir -p artifacts/
-          mv dist/promql-transform_linux_amd64/promql-transform artifacts/promql-transform-amd64
-          mv dist/promql-transform_linux_arm64/promql-transform artifacts/promql-transform-arm64
+          mkdir -p artifacts/release
+          find artifacts -type f | awk -F/ '{ print $2 }' | xargs -I {} cp artifacts/{}/promql-transform artifacts/release/{}
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          name: "Revision ${{ steps.getrev.outputs.rev }}"
-          omitBody: "true"
-          artifacts: "artifacts/*"
-          tag: "rev${{ steps.getrev.outputs.rev }}"
+          name: "Release ${{ steps.date.outputs.date }}"
+          omitBody: true
+          artifacts: "artifacts/release/*"
+          tag: "rel-${{ steps.date.outputs.date }}"
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload amd64 resource revision to CharmHub
+
+  charmhubrelease:
+    name: Release to CharmHub
+    runs-on: ubuntu-latest
+    needs:
+      - ghrelease
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        charm: [prometheus-k8s, grafana-k8s]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts/
+      - name: Install charmcraft
+        run: |
+          sudo snap install charmcraft --classic
+      - id: charmhubupload
+        name: Upload ${{matrix.arch}} resource revision to ${{matrix.charm}} charm
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
         run: |
-          charmcraft upload-resource ${{ matrix.charm }} promql-transform-amd64 --file artifacts/promql-transform-amd64
-      - name: Upload arm64 resource revision to CharmHub
-        env:
-          CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
+          if output=$(charmcraft upload-resource ${{ matrix.charm }} promql-transform-${{matrix.arch}} --file artifacts/promql-transform-${{matrix.arch}}/promql-transform); then
+            if revision=$(echo "${output}" | sed 's/^Revision \([0-9]\{1,\}\) .*$/\1/'); then
+              echo "::set-output name=rev::${revision}"
+            fi
+          else
+            echo "charmcraft upload-resource failed: ${output}"
+            exit 1
+          fi
+
+          if [ -z "${revision}" ]; then
+            echo "No revision found in the output of charmcraft upload-resource:\n${output}"
+            exit 2
+          fi
+      - name: Change perms on GITHUB_WORKSPACE
+        # Workaround for Git 2.34, see https://github.com/rickstaa/action-create-tag/issues/10
         run: |
-          charmcraft upload-resource ${{ matrix.charm }} promql-transform-arm64 --file artifacts/promql-transform-arm64
+          sudo chown -R root:root $GITHUB_WORKSPACE
+          sudo chmod -R 0777 $GITHUB_WORKSPACE
+      - name: Create git tag for ${{matrix.charm}} charm, ${{matrix.arch}} architecture
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "${{ matrix.charm }}-rev${{ steps.charmhubupload.outputs.rev }}"
+          message: "Resource revision ${{ matrix.charm }}/${{ steps.charmhubupload.outputs.rev }}"


### PR DESCRIPTION
## Issue
Expand the github workflows so they automatically publish resources to any charm which needs it.

## Solution
Use a matrix in the workflow instead of hardcoding prometheus only

## Release Notes
Automatically publish resources to more charms than just prometheus